### PR TITLE
Make one sided truncated normal distributions differentiable

### DIFF
--- a/TruncatedNormal.py
+++ b/TruncatedNormal.py
@@ -73,11 +73,19 @@ class TruncatedStandardNormal(Distribution):
 
     @staticmethod
     def _little_phi(x):
-        return (-(x ** 2) * 0.5).exp() * CONST_INV_SQRT_2PI
+        if x.isinf():
+            return torch.zeros(x.size()).to(x)
+        else:
+            return (-(x ** 2) * 0.5).exp() * CONST_INV_SQRT_2PI
 
     @staticmethod
     def _big_phi(x):
-        return 0.5 * (1 + (x * CONST_INV_SQRT_2).erf())
+        if x.isposinf():
+            return torch.ones(x.size()).to(x)
+        elif x.isneginf():
+            return torch.zeros(x.size()).to(x)
+        else:
+            return 0.5 * (1 + (x * CONST_INV_SQRT_2).erf())
 
     @staticmethod
     def _inv_big_phi(x):


### PR DESCRIPTION
# Problem

One sided truncated normal distributions are not differentiable with respect to their parameters.

# Solution

Add explicit handling of truncated normal distributions when calculating the probability density and cumulative distribution function.
